### PR TITLE
36 create account tests

### DIFF
--- a/frontend/src/__tests__/signup.test.js
+++ b/frontend/src/__tests__/signup.test.js
@@ -1,3 +1,0 @@
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import signup from "frontend/src/pages/Signup.jsx";
-

--- a/frontend/src/__tests__/signup.test.jsx
+++ b/frontend/src/__tests__/signup.test.jsx
@@ -117,9 +117,59 @@ describe("Signup Component", () => {
           });
     });
 
-    // TODO: Case sensitivity in emails
+    it("submits email as lowercase regardless of input", async () => {
+        const email_input = screen.getByPlaceholderText("Enter your email");
+        const name_input = screen.getByPlaceholderText("Enter your name");
+        const password_input = screen.getByPlaceholderText("Enter your password");
+        const confirm_password_input = screen.getByPlaceholderText("Confirm your password");
+
+
+        fireEvent.change(email_input, { target: { value: "Test@example.COM" } });
+        fireEvent.change(name_input, { target: { value: "TestUser" } });
+        fireEvent.change(password_input, { target: { value: "password123" } });
+        fireEvent.change(confirm_password_input, { target: { value: "password123" } });
+
+        fireEvent.submit(screen.getByRole("button", { name: /sign up/i }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledWith(
+              "http://localhost:5000/api/register",
+              expect.objectContaining({
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    email: "test@example.com",
+                    name: "TestUser",
+                    password: "password123",
+                  }),
+              })
+            );
+          });
+
+    });
 
     // TODO: edge cases - like a password that is only made of spaces
+    it("appropriate length password of only spaces submitted", async () => {
+        const password_input = screen.getByPlaceholderText("Enter your password");
+        fireEvent.change(password_input, { target: { value: "                " } });
+
+        fireEvent.submit(screen.getByRole("button", { name: /sign up/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByText(/password cannot contain spaces/i)).toBeInTheDocument();
+        });
+    });
+
+    it("password of length more than 25 submitted", async () => {
+        const password_input = screen.getByPlaceholderText("Enter your password");
+        fireEvent.change(password_input, { target: { value: "abcdefghijklmnopqrstuvwxyz" } });
+
+        fireEvent.submit(screen.getByRole("button", { name: /sign up/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByText(/password cannot be more than 20 characters/i)).toBeInTheDocument();
+        });
+    });
 
     // TODO: duplicate email case - when integrated with backend
 

--- a/frontend/src/__tests__/signup.test.jsx
+++ b/frontend/src/__tests__/signup.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import Signup from "/Users/siyarajpal/Desktop/Winter 25/CSE 210/taskagotchi/frontend/src/pages/Signup.jsx";
+import Signup from "../pages/Signup.jsx";
 import { describe, it, vi, expect, beforeEach, afterEach } from "vitest";
 
 beforeEach(() => {

--- a/frontend/src/__tests__/signup.test.jsx
+++ b/frontend/src/__tests__/signup.test.jsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import Signup from "/Users/siyarajpal/Desktop/Winter 25/CSE 210/taskagotchi/frontend/src/pages/Signup.jsx";
 import { describe, it, vi, expect, beforeEach, afterEach } from "vitest";
-import { wait } from "@testing-library/user-event/dist/cjs/utils/index.js";
 
 beforeEach(() => {
     vi.spyOn(global, "fetch").mockResolvedValue({

--- a/frontend/src/__tests__/signup.test.jsx
+++ b/frontend/src/__tests__/signup.test.jsx
@@ -1,0 +1,127 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import Signup from "/Users/siyarajpal/Desktop/Winter 25/CSE 210/taskagotchi/frontend/src/pages/Signup.jsx";
+import { describe, it, vi, expect, beforeEach, afterEach } from "vitest";
+import { wait } from "@testing-library/user-event/dist/cjs/utils/index.js";
+
+beforeEach(() => {
+    vi.spyOn(global, "fetch").mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: "User registered successfully" }),
+    });
+  });
+  
+  afterEach(() => {
+    vi.restoreAllMocks(); // Resets mock between tests
+  });
+
+describe("Signup Component", () => {
+    beforeEach(() => {
+    render(<Signup />);
+    });
+
+
+    // ensuring the form renders correctly
+    it("render form correctly", () => {
+        expect(screen.getByRole("heading", { name: /sign up/i })).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("Enter your email")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("Enter your name")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("Enter your password")).toBeInTheDocument();
+        expect(screen.getByPlaceholderText("Confirm your password")).toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /Sign up/i })).toBeInTheDocument();
+        expect(screen.getByRole("link", { name: /Go to log in/i})).toBeInTheDocument();
+    })
+
+    //allows users to type in the text fields
+    it("takes user input", () => {
+        const email_input = screen.getByPlaceholderText("Enter your email");
+        const name_input = screen.getByPlaceholderText("Enter your name");
+        const password_input = screen.getByPlaceholderText("Enter your password");
+        const confirm_password_input = screen.getByPlaceholderText("Confirm your password");
+
+
+        fireEvent.change(email_input, { target: { value: "test@example.com" } });
+        fireEvent.change(name_input, { target: { value: "TestUser" } });
+        fireEvent.change(password_input, { target: { value: "password123" } });
+        fireEvent.change(confirm_password_input, { target: { value: "password123" } });
+
+        expect(email_input).toHaveValue("test@example.com");
+        expect(name_input).toHaveValue("TestUser");
+        expect(password_input).toHaveValue("password123");
+        expect(confirm_password_input).toHaveValue("password123");
+    });
+
+    //test error messages on empty form
+    it("empty form on submit", async () => {
+        fireEvent.submit(screen.getByRole("button", { name: /sign up/i }));
+
+        await waitFor(() => {
+            expect(screen.getByText("Email is required")).toBeInTheDocument();
+            expect(screen.getByText("Password is required")).toBeInTheDocument();
+            expect(screen.getByText("Name is required")).toBeInTheDocument();
+            expect(screen.getByText("Confirm Password is required")).toBeInTheDocument();
+        });
+    });
+
+    //test error messages when passwords don't match
+    it("passwords don't match on submit", async () => {
+
+        fireEvent.change(screen.getByPlaceholderText("Enter your email"), {
+            target: { value: "test@example.com" },
+          });
+
+
+        fireEvent.change(screen.getByPlaceholderText("Enter your name"), {
+            target: {value: "test" },
+        });
+
+        fireEvent.change(screen.getByPlaceholderText("Enter your password"), {
+            target: {value: "password123"},
+        });
+
+        fireEvent.change(screen.getByPlaceholderText("Confirm your password"), {
+            target: {value: "password456"},
+        });
+
+        fireEvent.click(screen.getByRole("button", { name: /sign up/i }));
+
+        await waitFor(() => {
+            expect(screen.queryByText(/passwords do not match/i)).toBeInTheDocument();
+        });
+
+    });
+
+    // ensuring fetch is called when submit is clicked
+    it("fetch on submit", async () => {
+        fireEvent.change(screen.getByPlaceholderText("Enter your email"), {
+            target: { value: "test@example.com" },
+          });
+
+
+        fireEvent.change(screen.getByPlaceholderText("Enter your name"), {
+            target: {value: "test" },
+        });
+
+        fireEvent.change(screen.getByPlaceholderText("Enter your password"),  {
+            target: {value: "password123"},
+        });
+
+        fireEvent.change(screen.getByPlaceholderText("Confirm your password"), {
+            target: {value: "password123"}
+        });
+
+        fireEvent.submit(screen.getByRole("button", { name: /sign up/i }));
+
+        await waitFor(() => {
+            expect(fetch).toHaveBeenCalledTimes(1);
+            expect(fetch).toHaveBeenCalledWith("http://localhost:5000/api/register", expect.any(Object));
+          });
+    });
+
+    // TODO: Case sensitivity in emails
+
+    // TODO: edge cases - like a password that is only made of spaces
+
+    // TODO: duplicate email case - when integrated with backend
+
+});
+

--- a/frontend/src/__tests__/signup.test.jsx
+++ b/frontend/src/__tests__/signup.test.jsx
@@ -10,7 +10,7 @@ beforeEach(() => {
   });
   
   afterEach(() => {
-    vi.restoreAllMocks(); // Resets mock between tests
+    vi.restoreAllMocks();
   });
 
 describe("Signup Component", () => {
@@ -116,6 +116,7 @@ describe("Signup Component", () => {
           });
     });
 
+    //test email input as lower case
     it("submits email as lowercase regardless of input", async () => {
         const email_input = screen.getByPlaceholderText("Enter your email");
         const name_input = screen.getByPlaceholderText("Enter your name");
@@ -147,7 +148,7 @@ describe("Signup Component", () => {
 
     });
 
-    // TODO: edge cases - like a password that is only made of spaces
+    // test a password that is only made of spaces - should not be allowed
     it("appropriate length password of only spaces submitted", async () => {
         const password_input = screen.getByPlaceholderText("Enter your password");
         fireEvent.change(password_input, { target: { value: "                " } });
@@ -159,6 +160,7 @@ describe("Signup Component", () => {
         });
     });
 
+    // test a password of length more than 25 - should not be allowed
     it("password of length more than 25 submitted", async () => {
         const password_input = screen.getByPlaceholderText("Enter your password");
         fireEvent.change(password_input, { target: { value: "abcdefghijklmnopqrstuvwxyz" } });

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -38,11 +38,18 @@ const SignupPage = () => {
     
             //checks if email and password, and username are present
             if (!form_data.email) {
-            curr_errs.email = "Email is required";
+                curr_errs.email = "Email is required";
             }
     
             if (!form_data.password) {
                 curr_errs.password = "Password is required";
+            } else {
+                if(form_data.password.includes(" ")) {
+                    curr_errs.password = "Password cannot contain spaces";
+                }
+                if(form_data.password.length > 20) {
+                    curr_errs.password = "Password cannot be more than 20 characters";
+                }
             }
     
             if (!form_data.name) {
@@ -57,6 +64,11 @@ const SignupPage = () => {
             else if (form_data.password !== confirm_password) {
                 curr_errs.confirm_password = "Passwords do not match";
             }
+
+            const submission_data = {
+                ...form_data,
+                email: form_data.email.toLowerCase(), // Email converted to lowercase here
+              };
     
             if (Object.keys(curr_errs).length > 0) {
                 set_errs(curr_errs);
@@ -71,7 +83,7 @@ const SignupPage = () => {
                     headers: {
                         "Content-Type": "application/json",
                     },
-                    body: JSON.stringify(form_data),
+                    body: JSON.stringify(submission_data),
                 });
     
                 const data = await response.json();
@@ -93,7 +105,7 @@ const SignupPage = () => {
     
       
             //Sanity check
-            console.log("Form Submitted:", form_data);
+            console.log("Form Submitted:", submission_data);
         };
 
     return (

--- a/frontend/src/pages/Signup.jsx
+++ b/frontend/src/pages/Signup.jsx
@@ -155,7 +155,7 @@ const SignupPage = () => {
                                 value={confirm_password}
                                 onChange={handle_input}
                                 className="w-full p-1 mb-2 border border-black rounded-lg bg-white"
-                                placeholder="Confirm you password"
+                                placeholder="Confirm your password"
                             />
                             {errors.confirm_password && <p className="text-red-500 text-xs">{errors.confirm_password}</p>}
                         </div>


### PR DESCRIPTION
Added all possible frontend tests for create account, besides any connection to backend.

What still needs to be done, when middleware backend stuff gets figured out (backend calls are mocked right now):

- [ ] Add tests to ensure duplicate emails cannot be added & user receive proper error message
- [ ] Add test to ensure that case sensitivity is properly managed given an existing user 
- [ ] Add test to ensure user is directed to the correct homepage